### PR TITLE
Readme changes, changelog added, include package version in manual.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,3 @@
+Changes for 1.1-0110:
+- Images compressed.
+- Minor Typos.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
 Changes for 1.1-0110:
 - Images compressed.
 - Minor Typos.
+- Change version string to mirrior packaging,
+this will aid in users reporting errors or providing outdated information.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,24 @@
 Lite Manual
 ================
 
-Authors - [Jerry Bezencon,](https://github.com/linuxlite/) [Bill Hahnen,](https://github.com/gold-finger/) [Misko-2083,](https://github.com/Misko-2083/) [Adam Grubbs,](https://github.com/argrubbs/) [John Jenkins](https://github.com/shaggytwodope/)
+The Linux Lite Help and Support Manual. Available offline on Linux Lite, or viewable
+online [here](https://linuxliteos.com/manual).
 
 If you would like to write tutorials for this manual,
-please send me an email: [valtam@linuxliteos.com](mailto:valtam@linuxliteos.com)
+please send an email to: [valtam@linuxliteos.com](mailto:valtam@linuxliteos.com)
 
 ![](http://i.imgur.com/YqNlz2F.png)
+
+
+
+## License ![License](https://img.shields.io/badge/license-GPLv2-green.svg)
+
+This project is under the GPLv2 license. Unless otherwise stated in indavidual files.
+
+##Authors
+- [Adam Grubbs](https://github.com/argrubbs/)
+- [Bill Hahnen](https://github.com/gold-finger/)
+- [Jerry Bezencon](https://github.com/linuxlite/)
+- [Johnathan "ShaggyTwoDope" Jenkins](https://github.com/shaggytwodope/)
+- [Misko-2083](https://github.com/Misko-2083/)
+

--- a/usr/share/doc/litemanual/start.html
+++ b/usr/share/doc/litemanual/start.html
@@ -88,7 +88,7 @@ i    {font-style: italic;}
 
 					<h2>Welcome to Linux Lite - simple, fast, free.</h2>
 					<p>Thank you for choosing the Linux Lite Operating System.</p>
-					<p><b>Version:</b> 2.8 | Date published:  15th February, 2016</p>
+					<p><b>Version:</b> 1.1-0110 for Series: 2.8 | Date published:  15th February, 2016</p>
 					<p><b>What's New:</b> Updated Hardware DB links</p>
 					<p><b>Authors:</b> Bill Hahnen, Milos Pavlovic, Adam Grubbs, John Jenkins, Jerry Bezencon</p>
 


### PR DESCRIPTION
The release version for example: 2.8 is not a version for a release.
This creates what I consider an issue with users possibly reporting
flaws or errors in the guides provided. Instead we mention version
from the packaging +Series: 2.8 as a solution.

I added a changelog as with all other projects. I think this is self
explainatory.

Some tweaks to the readme.